### PR TITLE
Keyboard does not close when multiple DraggableText are placed.

### DIFF
--- a/ACEDrawingView/ACEDrawingLabelView.m
+++ b/ACEDrawingView/ACEDrawingLabelView.m
@@ -376,9 +376,9 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
 
 - (void)contentTapped:(UITapGestureRecognizer*)tapGesture
 {
-  if (tapGesture.view == self.labelTextField && !self.isShowingEditingHandles) {
-    [self showEditingHandles];
-  }
+    if (tapGesture.view == self.labelTextField && !self.isShowingEditingHandles) {
+      [self showEditingHandles];
+    }
 }
 
 - (void)closeTap:(UITapGestureRecognizer *)recognizer

--- a/ACEDrawingView/ACEDrawingLabelView.m
+++ b/ACEDrawingView/ACEDrawingLabelView.m
@@ -167,8 +167,8 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
         [self addGestureRecognizer:moveGesture];
         
         UITapGestureRecognizer *singleTapShowHide = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(contentTapped:)];
-        [self addGestureRecognizer:singleTapShowHide];
-        
+        [self.labelTextField addGestureRecognizer:singleTapShowHide];
+
         UITapGestureRecognizer *closeTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(closeTap:)];
         [self.closeButton addGestureRecognizer:closeTap];
         
@@ -376,12 +376,9 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
 
 - (void)contentTapped:(UITapGestureRecognizer*)tapGesture
 {
-    if (self.isShowingEditingHandles) {
-        [self hideEditingHandles];
-        [self.superview bringSubviewToFront:self];
-    } else {
-        [self showEditingHandles];
-    }
+  if (tapGesture.view == self.labelTextField && !self.isShowingEditingHandles) {
+    [self showEditingHandles];
+  }
 }
 
 - (void)closeTap:(UITapGestureRecognizer *)recognizer


### PR DESCRIPTION
tapGestureの対象をTextFieldに変更
タップされた要素がTextFieldであれば処理を実行するよう修正